### PR TITLE
Content save error fix

### DIFF
--- a/components/Editable.php
+++ b/components/Editable.php
@@ -70,7 +70,7 @@ class Editable extends ComponentBase
 
         $fileName = post('file');
         $template = Content::load($this->getTheme(), $fileName);
-        $template->fill(['content' => post('content')]);
+        $template->fill(['markup' => post('content')]);
         $template->save();
     }
 


### PR DESCRIPTION
Fixes the error `The property "content" cannot be set` when saving the edited content.
