### PR TITLE
Select the correct file if we have installed the Rainlab translate plugi...

### DIFF
--- a/components/Editable.php
+++ b/components/Editable.php
@@ -57,6 +57,13 @@ class Editable extends ComponentBase
         $this->file = $this->property('file');
         $this->fileMode = File::extension($this->property('file'));
 
+		 if (class_exists('\RainLab\Translate\Classes\Translator')){
+            $locale = \RainLab\Translate\Classes\Translator::instance()->getLocale();
+            $fileName = substr_replace($this->file, '.'.$locale, strrpos($this->file, '.'), 0);
+            if (($content = Content::loadCached($this->page->controller->getTheme(), $fileName)) !== null)
+                $this->file = $fileName;
+        }
+		
         if (!$this->isEditor)
             return $this->renderContent($this->file);
 


### PR DESCRIPTION
When we have several files in different languages do not always choose the right and the principal is selected. With this arrangement solves the problem.