### PR TITLE
Button Issue Fix

### DIFF
--- a/assets/css/editable.css
+++ b/assets/css/editable.css
@@ -21,11 +21,12 @@
   border: none;
   width: 26px;
   height: 30px;
-  background-size: 60px 30px;
+  background-size: auto 30px;
   text-indent: -9999px;
   line-height: 0;
   overflow: hidden;
   border-radius: 1px;
+  padding: 0;
 }
 .control-editable button.editable-edit-button {
   background-color: transparent;
@@ -33,6 +34,7 @@
 }
 .control-editable button.editable-edit-button:hover {
   background-position: 100% 0;
+  background-size: auto 30px;
 }
 .control-editable button.editable-save-button,
 .control-editable button.editable-cancel-button {
@@ -45,6 +47,7 @@
 }
 .control-editable button.editable-save-button:hover {
   background-position: 100% 0;
+  background-size: auto 30px;
 }
 .control-editable button.editable-cancel-button {
   margin-right: 4px;
@@ -52,4 +55,5 @@
 }
 .control-editable button.editable-cancel-button:hover {
   background-position: 100% 0;
+  background-size: auto 30px;
 }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -2,3 +2,4 @@
 1.0.2: Minor security update
 1.0.3: Content save error fix
 1.0.4: Fixed references to Redactor's "get" and "destroy" methods
+1.0.5: Fixed button css issue


### PR DESCRIPTION
Fixes issues with edit, save & cancel buttons.

When hovering over editable area:
![editable-1](https://cloud.githubusercontent.com/assets/7501909/6210919/7b0e7c8c-b5cc-11e4-8e1f-9676bf441207.jpg)

When hovering over button:
![editable-2](https://cloud.githubusercontent.com/assets/7501909/6210923/7dfd650c-b5cc-11e4-8f0e-5b9f45d4e0f7.jpg)

Seems to just be an issue with padding on the buttons, along with ```background-size``` on hover.