### PR TITLE
Fixes sleight button CSS issue

### DIFF
--- a/assets/css/editable.css
+++ b/assets/css/editable.css
@@ -7,6 +7,7 @@
   height: 20px;
   width: 50px;
   pointer-events: none;
+  z-index: 9000;
 }
 .control-editable.active,
 .control-editable.visible {
@@ -19,14 +20,15 @@
 .control-editable button {
   pointer-events: auto;
   border: none;
-  width: 26px;
-  height: 30px;
-  background-size: auto 30px;
+  width: 26px !important;
+  height: 30px !important;
+  padding: 0 !important;
+  background-size: 60px 30px;
   text-indent: -9999px;
   line-height: 0;
   overflow: hidden;
   border-radius: 1px;
-  padding: 0;
+  min-height: 0;
 }
 .control-editable button.editable-edit-button {
   background-color: transparent;
@@ -34,7 +36,6 @@
 }
 .control-editable button.editable-edit-button:hover {
   background-position: 100% 0;
-  background-size: auto 30px;
 }
 .control-editable button.editable-save-button,
 .control-editable button.editable-cancel-button {
@@ -47,7 +48,6 @@
 }
 .control-editable button.editable-save-button:hover {
   background-position: 100% 0;
-  background-size: auto 30px;
 }
 .control-editable button.editable-cancel-button {
   margin-right: 4px;
@@ -55,5 +55,4 @@
 }
 .control-editable button.editable-cancel-button:hover {
   background-position: 100% 0;
-  background-size: auto 30px;
 }

--- a/assets/css/editable.css
+++ b/assets/css/editable.css
@@ -40,7 +40,7 @@
 .control-editable button.editable-save-button,
 .control-editable button.editable-cancel-button {
   height: 26px;
-  background-color: #f0f0f0;
+  background-color: white;
   margin: 4px 2px;
 }
 .control-editable button.editable-save-button {

--- a/assets/less/editable.less
+++ b/assets/less/editable.less
@@ -38,7 +38,7 @@
         &.editable-save-button,
         &.editable-cancel-button {
             height: 26px;
-            background-color: #f0f0f0;
+            background-color: white;
             margin: 4px 2px;
         }
         &.editable-save-button {

--- a/assets/less/editable.less
+++ b/assets/less/editable.less
@@ -23,12 +23,12 @@
         width: 26px !important;
         height: 30px !important;
         padding: 0 !important;
-        margin: 0 !important;
         background-size: 60px 30px;
         text-indent: -9999px;
         line-height: 0;
         overflow: hidden;
         border-radius: 1px;
+        min-height: 0;
 
         &.editable-edit-button {
             background-color: transparent;

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -3,3 +3,4 @@
 1.0.3: Content save error fix
 1.0.4: Fixed references to Redactor's "get" and "destroy" methods
 1.0.5: Fixed button css issue
+1.0.6: Fixed button css issue


### PR DESCRIPTION
Fixes sleight CSS issue on buttons

Was:

![1](https://cloud.githubusercontent.com/assets/7501909/8252849/8b6b7c68-1681-11e5-8251-6dcf61a31303.jpg)
![2](https://cloud.githubusercontent.com/assets/7501909/8252851/8dff670a-1681-11e5-94a4-97ede72f0107.jpg)

Now:

![3](https://cloud.githubusercontent.com/assets/7501909/8252859/992e846c-1681-11e5-875f-87036ef871e0.jpg)
![4 1](https://cloud.githubusercontent.com/assets/7501909/8252860/9bbac5b0-1681-11e5-80e4-59b7bf6606c7.jpg)

Also removed grey BG overflow:

![4 2](https://cloud.githubusercontent.com/assets/7501909/8252869/ab70f89e-1681-11e5-9b23-0389a1b38e0e.jpg)
